### PR TITLE
Fix bug related to linking process steps to the preparation object type (#15)

### DIFF
--- a/src/sample_preparation_widgets.py
+++ b/src/sample_preparation_widgets.py
@@ -2012,13 +2012,16 @@ class RegisterPreparationWidget(ipw.VBox):
 
                 new_sample_name = f"{current_sample_name}:{process_code}"
                 self.sample_preparation_object.props["name"] = f"PREP_{new_sample_name}"
+                self.sample_preparation_object.add_children(new_process_object.permId)
                 utils.update_openbis_object(self.sample_preparation_object)
 
                 new_process_object.props = process_properties
-                new_process_object.parents = [
-                    self.sample_preparation_object,
-                    current_sample,
-                ]
+                new_process_object.add_parents(
+                    [
+                        self.sample_preparation_object,
+                        current_sample,
+                    ]
+                )
                 utils.update_openbis_object(new_process_object)
 
                 new_sample = utils.create_openbis_object(


### PR DESCRIPTION
Fix bug related to linking process steps to the preparation object type (#15). Setting children using self.sample_preparation_object.children(new_process_object.permId) did not work properly and had to replace it by add_children(). Also replaced .parents by .add_parents