### PR TITLE
17 fix/openbis connection

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -96,7 +96,7 @@ def connect_openbis_aiida(eln_url="https://local.openbis.ch"):
         config = read_json(eln_config)
         eln_token = config[eln_url]["token"]
         openbis_session, session_data = connect_openbis(eln_url, eln_token)
-    except Exception:
+    except KeyError:
         eln_token = ""
         openbis_session, session_data = None, None
     return openbis_session, session_data


### PR DESCRIPTION
Wrap the connection to openBIS in a try/except block, because if the user has not configured the connection to openBIS using Configure ELN, an error will occur. Return `None` if the connection fails (#17).