### PR TITLE
Correct typo in special storage conditions in openbis_objects.py

### DIFF
--- a/schema/openbis_objects.py
+++ b/schema/openbis_objects.py
@@ -104,7 +104,7 @@ class SpecialStorageConditionsEnum(str, Enum):
     Freezer = "Freezer"
     Dark = "Dark"
     Flammable = "Flammable"
-    Poisenous = "Poisenous"
+    Poisonous = "Poisonous"
 
 
 class CurrencyUnitEnum(str, Enum):


### PR DESCRIPTION
Replaced poisenous by poisonous (#42)