### PR TITLE
Fix: Check measurement when saving preparation

### DIFF
--- a/src/sample_preparation_widgets.py
+++ b/src/sample_preparation_widgets.py
@@ -1597,9 +1597,8 @@ class RegisterPreparationWidget(ipw.VBox):
             )
             experiment_project_code = experiment_object.project.identifier
 
-            # TODO: Replace this by a non-cached get_openbis_object function
-            current_sample = self.openbis_session.get_object(
-                sample_ident=current_sample_id
+            current_sample = utils.get_openbis_object(
+                self.openbis_session, sample_ident=current_sample_id
             )
 
             # If sample was used in a measurement session, a new preparation should start

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,7 +4,6 @@ from pybis import Openbis
 import yaml
 import datetime
 import os
-from functools import lru_cache
 import ipywidgets as ipw
 import io
 import contextlib
@@ -26,17 +25,14 @@ def get_openbis_objects(openbis_session, **kwargs):
     return openbis_session.get_objects(**kwargs)
 
 
-@lru_cache(maxsize=5000)
 def get_openbis_object(openbis_session, **kwargs):
     return openbis_session.get_object(**kwargs)
 
 
-@lru_cache(maxsize=5000)
 def get_openbis_collection(openbis_session, **kwargs):
     return openbis_session.get_collection(**kwargs)
 
 
-@lru_cache(maxsize=5000)
 def get_openbis_property_type(openbis_session, **kwargs):
     return openbis_session.get_property_type(**kwargs)
 


### PR DESCRIPTION
I moved the measurement check to occur when saving a new preparation and removed the cached functions. The issue I encountered was that when I had both the sample preparation and sample measurement interfaces open, starting a new preparation for a sample I was measuring did not create a new preparation object, which was incorrect. Additionally, after moving the check inside the saving function, it still didn’t work correctly because it was loading an outdated version of the sample object cached by the `get_openbis_object` function. I had used this caching option in previous versions, but since the interface now works fine without it, I removed it for improved reliability (#51).