### PR TITLE
Stop copying measurements_uploader.py into the data folder 

### DIFF
--- a/nanonis_importer/nanonis_importer.py
+++ b/nanonis_importer/nanonis_importer.py
@@ -14,7 +14,7 @@
 #
 import sys
 
-sys.path.append("/home/jovyan/aiida-openbis/")
+sys.path.append("/home/jovyan/aiidalab-openbis/")
 import os
 from pybis import Openbis, ImagingControl
 import pybis.imaging as imaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     aiida-core~=2.5, <3
     ase==3.26.0
     scikit-learn==1.6.1
-    pybis==1.37.4
+    pybis==6.7.0.0rc1
     rdkit==2025.9.1
     SPIEPy==0.2.1
     ipyfilechooser==0.6.0

--- a/src/measurements_uploader.py
+++ b/src/measurements_uploader.py
@@ -6,7 +6,7 @@ import argparse
 from pybis import Openbis
 import sys
 
-sys.path.append("/home/jovyan/apps/aiida-openbis/")
+sys.path.append("/home/jovyan/apps/aiidalab-openbis/")
 from src import utils
 from nanonis_importer.nanonis_importer import process_measurement_files
 

--- a/src/watchdog_widgets.py
+++ b/src/watchdog_widgets.py
@@ -5,7 +5,6 @@ from IPython.display import display, Javascript
 from . import utils, widgets
 import ipyfilechooser
 import atexit
-import shutil
 import subprocess
 import logging
 
@@ -227,13 +226,11 @@ class GenerateMeasurementsWatchdogWidget(ipw.VBox):
 
         measurement_session_id = measurement_session_object.permId
         measurements_directory = self.select_measurements_folder_widget.selected_path
-        watchdog_file = "src/measurements_uploader.py"
-        shutil.copy(watchdog_file, measurements_directory)
 
         watchdog_process = subprocess.Popen(
             [
                 "python",
-                f"{measurements_directory}/measurements_uploader.py",
+                "src/measurements_uploader.py",
                 "--openbis_url",
                 self.session_data["url"],
                 "--openbis_token",


### PR DESCRIPTION
* Stop copying measurements_uploader.py into the data folder 
* Corrected aiida-openbis to aiidalab-openbis path
* Corrected pybis version. 1.37.4 was not working with imaging data.