### PR TITLE
Fix editable install and ipywidgets 8 startup issues

### DIFF
--- a/0_home.ipynb
+++ b/0_home.ipynb
@@ -57,6 +57,7 @@
     "# Define the path to your existing script\n",
     "script_path = \"src/upload_logs_to_afs.py\"\n",
     "pid_file = \"logs/upload_logs.pid\"\n",
+    "os.makedirs(\"logs\", exist_ok=True)\n",
     "\n",
     "# Check if the process is already running to prevent duplicates\n",
     "already_running = False\n",

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ project_urls =
 
 [options]
 python_requires = >=3.9
-package = find:
+packages = find:
 install_requires =
     aiida-core~=2.5, <3
     ase==3.26.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     scikit-learn==1.6.1
     pybis==6.9.1.0rc1
     rdkit==2025.9.1
+    aiidalab-eln>=0.1.4
     SPIEPy==0.2.1
     ipyfilechooser==0.6.0
     langchain==0.3.27

--- a/src/sample_preparation_widgets.py
+++ b/src/sample_preparation_widgets.py
@@ -2245,7 +2245,7 @@ class RegisterActionWidget(ipw.VBox):
         self.action_icon = icon_mapping.get(action_type, "⚙️")
         if self.process_step_widget is not None:
             self.process_step_widget.refresh_action_icon_prefix(pending_action=self)
-        self.actions_accordion.set_title(self.action_index, self.action_icon)
+        self._set_action_title(self.action_icon)
 
         action_properties = (
             utils.get_openbis_object_type(self.openbis_session, type=action_type)
@@ -2732,10 +2732,14 @@ class RegisterActionWidget(ipw.VBox):
             comp_dropdown_widget.observe(add_component_ui, names="value")
 
         self.action_properties_widgets.children = action_properties_widgets
-        self.actions_accordion.set_title(self.action_index, self.get_action_title())
+        self._set_action_title(self.get_action_title())
 
     def change_action_title(self, change):
-        self.actions_accordion.set_title(self.action_index, self.get_action_title())
+        self._set_action_title(self.get_action_title())
+
+    def _set_action_title(self, title):
+        if self.action_index < len(self.actions_accordion.children):
+            self.actions_accordion.set_title(self.action_index, title)
 
     def get_action_title(self):
         for widget in self.action_properties_widgets.children:

--- a/src/sample_preparation_widgets.py
+++ b/src/sample_preparation_widgets.py
@@ -1265,12 +1265,10 @@ class RegisterPreparationWidget(ipw.VBox):
             ]
 
             # Reset new processes accordion
-            processes_accordion_children = list(self.new_processes_accordion.children)
-            for index, process_step in enumerate(processes_accordion_children):
-                self.new_processes_accordion.set_title(index, "")
+            self.new_processes_accordion.children = []
+            self.new_processes_accordion.titles = ()
 
             self.process_short_name = ""
-            self.new_processes_accordion.children = []
 
             # Refresh sample dropdown and sample history
             self.select_sample_dropdown.load_samples()
@@ -1679,11 +1677,8 @@ class RegisterProcessWidget(ipw.VBox):
             logger.info(f"Process {new_process_object.permId} created successfully.")
 
             # Reset new processes accordion
-            processes_accordion_children = list(self.new_processes_accordion.children)
-            for index, _ in enumerate(processes_accordion_children):
-                self.new_processes_accordion.set_title(index, "")
-
             self.new_processes_accordion.children = []
+            self.new_processes_accordion.titles = ()
 
             self.process_name_text.value = ""
             self.process_short_name_text.value = ""

--- a/src/sample_preparation_widgets.py
+++ b/src/sample_preparation_widgets.py
@@ -1920,8 +1920,11 @@ class RegisterProcessStepWidget(ipw.VBox):
             )
 
     def change_process_step_title(self, change):
-        title = self.name_textbox.value
-        self.processes_accordion.set_title(self.process_step_index, title)
+        self._set_process_step_title(self.name_textbox.value)
+
+    def _set_process_step_title(self, title):
+        if self.process_step_index < len(self.processes_accordion.children):
+            self.processes_accordion.set_title(self.process_step_index, title)
 
     def refresh_action_icon_prefix(self, pending_action=None):
         actions = list(self.actions_accordion.children)
@@ -1942,7 +1945,7 @@ class RegisterProcessStepWidget(ipw.VBox):
             else body_text
         )
         self.name_textbox.value = new_text
-        self.processes_accordion.set_title(self.process_step_index, new_text)
+        self._set_process_step_title(new_text)
 
     def remove_process_step(self, b):
         processes_accordion_children = list(self.processes_accordion.children)

--- a/src/sample_preparation_widgets.py
+++ b/src/sample_preparation_widgets.py
@@ -39,6 +39,12 @@ logging.basicConfig(
 )
 
 
+def set_accordion_children_titles(accordion, children, titles):
+    accordion.children = list(children)
+    for index, title in enumerate(titles):
+        accordion.set_title(index, title or "")
+
+
 class SampleHistoryWidget(ipw.VBox):
     def __init__(self, openbis_session):
         super().__init__()
@@ -69,7 +75,8 @@ class SampleHistoryWidget(ipw.VBox):
                         process_steps.append(parent_object)
             sample_parents = next_parents
         sample_history_children = []
-        for i, process_step in enumerate(process_steps):
+        sample_history_titles = []
+        for process_step in process_steps:
             process_step_widget = ProcessStepHistoryWidget(
                 self.openbis_session, process_step
             )
@@ -80,9 +87,11 @@ class SampleHistoryWidget(ipw.VBox):
                 + process_step_widget.registration_date
                 + ")"
             )
-            self.sample_history.set_title(i, process_step_title)
+            sample_history_titles.append(process_step_title)
 
-        self.sample_history.children = sample_history_children
+        set_accordion_children_titles(
+            self.sample_history, sample_history_children, sample_history_titles
+        )
         logger.info("Sample history loaded successfully.")
 
 
@@ -182,16 +191,18 @@ class ProcessStepHistoryWidget(ipw.VBox):
         actions_ids = self.openbis_object.props["actions"]
         if actions_ids:
             actions_accordion_children = []
-            for i, act_id in enumerate(actions_ids):
+            actions_accordion_titles = []
+            for act_id in actions_ids:
                 act_object = utils.get_openbis_object(
                     self.openbis_session, sample_ident=act_id
                 )
                 act_widget = ActionHistoryWidget(self.openbis_session, act_object)
                 actions_accordion_children.append(act_widget)
-                act_title = act_widget.name
-                self.actions_accordion.set_title(i, act_title)
+                actions_accordion_titles.append(act_widget.name)
 
-            self.actions_accordion.children = actions_accordion_children
+            set_accordion_children_titles(
+                self.actions_accordion, actions_accordion_children, actions_accordion_titles
+            )
 
     def load_observables(self):
         observables_ids = self.openbis_object.get_datasets(
@@ -199,14 +210,18 @@ class ProcessStepHistoryWidget(ipw.VBox):
         ).df.permId.values
         if observables_ids:
             observables_accordion_children = []
-            for i, obs_id in enumerate(observables_ids):
+            observables_accordion_titles = []
+            for obs_id in observables_ids:
                 obs_dataset = utils.get_openbis_dataset(self.openbis_session, obs_id)
                 obs_widget = ObservableHistoryWidget(self.openbis_session, obs_dataset)
                 observables_accordion_children.append(obs_widget)
-                obs_title = obs_widget.name_html.value
-                self.observables_accordion.set_title(i, obs_title)
+                observables_accordion_titles.append(obs_widget.name_html.value)
 
-            self.observables_accordion.children = observables_accordion_children
+            set_accordion_children_titles(
+                self.observables_accordion,
+                observables_accordion_children,
+                observables_accordion_titles,
+            )
 
 
 class ActionHistoryWidget(ipw.VBox):
@@ -1871,12 +1886,13 @@ class RegisterProcessStepWidget(ipw.VBox):
         for index, process_step in enumerate(processes_accordion_children):
             if index >= self.process_step_index:
                 process_step.process_step_index -= 1
-                self.processes_accordion.set_title(
-                    process_step.process_step_index, process_step.name_textbox.value
-                )
 
-        self.processes_accordion.set_title(num_process_steps - 1, "")
-        self.processes_accordion.children = processes_accordion_children
+        process_titles = [
+            process_step.name_textbox.value for process_step in processes_accordion_children
+        ]
+        set_accordion_children_titles(
+            self.processes_accordion, processes_accordion_children, process_titles
+        )
 
     def add_action(self, b):
         instrument_permid = self.instrument_dropdown.value
@@ -2688,19 +2704,17 @@ class RegisterActionWidget(ipw.VBox):
         for i in range(self.action_index, len(children)):
             children[i].action_index = i
 
-        self.actions_accordion.children = children
-
-        for i, action in enumerate(children):
+        action_titles = []
+        for action in children:
             action_name = ""
-            if self.action_properties_widgets.children:
+            if action.action_properties_widgets.children:
                 for widget in action.action_properties_widgets.children:
                     if widget.metadata.get("property_name", "") == "NAME":
                         action_name += widget.children[1].value
                         break
-            self.actions_accordion.set_title(i, action_name)
+            action_titles.append(action_name)
 
-        # Handle the accordion title edge case for the popped index
-        self.actions_accordion.set_title(len(children), "")
+        set_accordion_children_titles(self.actions_accordion, children, action_titles)
 
 
 class RegisterObservableWidget(ipw.VBox):
@@ -2873,15 +2887,16 @@ class RegisterObservableWidget(ipw.VBox):
         for i in range(self.observable_index, len(children)):
             children[i].observable_index = i
 
-        self.observables_accordion.children = children
-
-        for index, observable in enumerate(children):
+        observable_titles = []
+        for observable in children:
             observable_name = ""
-            if self.observable_properties_widgets.children:
+            if observable.observable_properties_widgets.children:
                 for widget in observable.observable_properties_widgets.children:
                     if widget.metadata.get("property_name", "") == "NAME":
                         observable_name += widget.children[1].value
                         break
-            self.observables_accordion.set_title(index, observable_name)
+            observable_titles.append(observable_name)
 
-        self.observables_accordion.set_title(len(children), "")
+        set_accordion_children_titles(
+            self.observables_accordion, children, observable_titles
+        )

--- a/src/sample_preparation_widgets.py
+++ b/src/sample_preparation_widgets.py
@@ -9,7 +9,7 @@ import time
 import threading
 import os
 import logging
-import custom_widgets as cw
+from . import custom_widgets as cw
 
 INTERFACE_CONFIG_INFO = utils.get_interface_config_info()
 ACTIONS_TYPES, ACTIONS_CODES = (

--- a/src/sample_preparation_widgets.py
+++ b/src/sample_preparation_widgets.py
@@ -43,23 +43,13 @@ def set_accordion_children_titles(accordion, children, titles):
     children = list(children)
     titles = list(titles)
 
-    for index in range(max(len(accordion.children), len(children))):
-        try:
-            accordion.set_title(index, "")
-        except IndexError:
-            pass
-
-    if not children:
-        accordion.children = []
-        accordion.selected_index = None
-        return
-
     accordion.children = children
-    for index, title in enumerate(titles):
-        accordion.set_title(index, title or "")
-
-    for index in range(len(titles), len(children)):
-        accordion.set_title(index, "")
+    accordion.titles = tuple(
+        (titles[index] if index < len(titles) else "") or ""
+        for index in range(len(children))
+    )
+    if not children:
+        accordion.selected_index = None
 
 
 class SampleHistoryWidget(ipw.VBox):
@@ -225,7 +215,7 @@ class ProcessStepHistoryWidget(ipw.VBox):
         observables_ids = self.openbis_object.get_datasets(
             type="OBSERVABLE"
         ).df.permId.values
-        if observables_ids:
+        if len(observables_ids) > 0:
             observables_accordion_children = []
             observables_accordion_titles = []
             for obs_id in observables_ids:

--- a/src/sample_preparation_widgets.py
+++ b/src/sample_preparation_widgets.py
@@ -40,9 +40,26 @@ logging.basicConfig(
 
 
 def set_accordion_children_titles(accordion, children, titles):
-    accordion.children = list(children)
+    children = list(children)
+    titles = list(titles)
+
+    for index in range(max(len(accordion.children), len(children))):
+        try:
+            accordion.set_title(index, "")
+        except IndexError:
+            pass
+
+    if not children:
+        accordion.children = []
+        accordion.selected_index = None
+        return
+
+    accordion.children = children
     for index, title in enumerate(titles):
         accordion.set_title(index, title or "")
+
+    for index in range(len(titles), len(children)):
+        accordion.set_title(index, "")
 
 
 class SampleHistoryWidget(ipw.VBox):
@@ -749,7 +766,14 @@ class RegisterPreparationWidget(ipw.VBox):
             self.openbis_session, self.new_processes_accordion, process_step_index
         )
         processes_accordion_children.append(new_process_step_widget)
-        self.new_processes_accordion.children = processes_accordion_children
+        set_accordion_children_titles(
+            self.new_processes_accordion,
+            processes_accordion_children,
+            [
+                process_step.name_textbox.value
+                for process_step in processes_accordion_children
+            ],
+        )
 
     def load_process(self, b):
         openbis_processes = utils.get_openbis_objects(
@@ -804,7 +828,14 @@ class RegisterPreparationWidget(ipw.VBox):
                         process_step=process_step,
                     )
                     processes_accordion_children.append(new_process_step_widget)
-                    self.new_processes_accordion.children = processes_accordion_children
+                    set_accordion_children_titles(
+                        self.new_processes_accordion,
+                        processes_accordion_children,
+                        [
+                            process_step.name_textbox.value
+                            for process_step in processes_accordion_children
+                        ],
+                    )
 
             self.load_processes_hbox.children = []
 
@@ -1417,7 +1448,14 @@ class RegisterProcessWidget(ipw.VBox):
             allow_observables=False,
         )
         processes_accordion_children.append(new_process_step_widget)
-        self.new_processes_accordion.children = processes_accordion_children
+        set_accordion_children_titles(
+            self.new_processes_accordion,
+            processes_accordion_children,
+            [
+                process_step.name_textbox.value
+                for process_step in processes_accordion_children
+            ],
+        )
 
     def save_process_steps(self, b):
         collection_id = self.select_collection_dropdown.value
@@ -1872,15 +1910,42 @@ class RegisterProcessStepWidget(ipw.VBox):
                 process_step_widget=self,
             )
             actions_accordion_children.append(new_action_widget)
-            self.actions_accordion.children = actions_accordion_children
+            set_accordion_children_titles(
+                self.actions_accordion,
+                actions_accordion_children,
+                [
+                    getattr(action, "action_icon", "")
+                    for action in actions_accordion_children
+                ],
+            )
 
     def change_process_step_title(self, change):
         title = self.name_textbox.value
         self.processes_accordion.set_title(self.process_step_index, title)
 
+    def refresh_action_icon_prefix(self, pending_action=None):
+        actions = list(self.actions_accordion.children)
+        if pending_action is not None and pending_action not in actions:
+            actions.append(pending_action)
+
+        action_icons = "".join(
+            getattr(action, "action_icon", "") for action in actions
+        )
+        current_text = self.name_textbox.value or ""
+        body_text = current_text
+        if current_text.startswith("[") and "]" in current_text:
+            body_text = current_text[current_text.find("]") + 1 :].lstrip()
+
+        new_text = (
+            f"[{action_icons}] {body_text}".rstrip()
+            if action_icons
+            else body_text
+        )
+        self.name_textbox.value = new_text
+        self.processes_accordion.set_title(self.process_step_index, new_text)
+
     def remove_process_step(self, b):
         processes_accordion_children = list(self.processes_accordion.children)
-        num_process_steps = len(processes_accordion_children)
         processes_accordion_children.pop(self.process_step_index)
 
         for index, process_step in enumerate(processes_accordion_children):
@@ -1907,7 +1972,14 @@ class RegisterProcessStepWidget(ipw.VBox):
                 process_step_widget=self,
             )
             actions_accordion_children.append(new_action_widget)
-            self.actions_accordion.children = actions_accordion_children
+            set_accordion_children_titles(
+                self.actions_accordion,
+                actions_accordion_children,
+                [
+                    getattr(action, "action_icon", "")
+                    for action in actions_accordion_children
+                ],
+            )
 
     def add_observable(self, b):
         instrument_permid = self.instrument_dropdown.value
@@ -1922,7 +1994,18 @@ class RegisterProcessStepWidget(ipw.VBox):
                 process_step_widget=self,
             )
             observables_accordion_children.append(new_observable_widget)
-            self.observables_accordion.children = observables_accordion_children
+            set_accordion_children_titles(
+                self.observables_accordion,
+                observables_accordion_children,
+                [
+                    observable.observable_properties_widgets.children[0]
+                    .children[1]
+                    .value
+                    if observable.observable_properties_widgets.children
+                    else ""
+                    for observable in observables_accordion_children
+                ],
+            )
 
 
 class RegisterActionWidget(ipw.VBox):
@@ -2149,42 +2232,16 @@ class RegisterActionWidget(ipw.VBox):
     def load_action_properties(self, change):
         action_type = self.action_type_dropdown.value
         if action_type == "-1":
+            self.action_icon = ""
             self.action_properties_widgets.children = []
+            if self.process_step_widget is not None:
+                self.process_step_widget.refresh_action_icon_prefix()
             return
 
         icon_mapping = INTERFACE_CONFIG_INFO["actions_types_icons"]
         self.action_icon = icon_mapping.get(action_type, "⚙️")
-        current_text = self.process_step_widget.name_textbox.value
-
-        if current_text.startswith("[") and "]" in current_text:
-            close_idx = current_text.find("]")
-            current_icons_str = current_text[1:close_idx]
-
-            # 1. Safely break the string into a list of complete emojis
-            icons_list = []
-            for char in current_icons_str:
-                # If the character is a modifier (like \ufe0f or ZWJ), attach it to the previous emoji
-                if char in ("\ufe0f", "\u200d") and icons_list:
-                    icons_list[-1] += char
-                else:
-                    icons_list.append(char)
-
-            # 2. Safely replace or append the new icon based on the index
-            if self.action_index < len(icons_list):
-                icons_list[self.action_index] = self.action_icon
-            else:
-                # If adding a brand new action
-                icons_list.append(self.action_icon)
-
-            # 3. Join them back together and rebuild the text
-            new_icons_str = "".join(icons_list)
-            new_text = f"[{new_icons_str}]" + current_text[close_idx + 1 :]
-
-        else:
-            # Create the brackets if they don't exist yet
-            new_text = f"[{self.action_icon}] {current_text}"
-
-        self.process_step_widget.name_textbox.value = new_text
+        if self.process_step_widget is not None:
+            self.process_step_widget.refresh_action_icon_prefix(pending_action=self)
         self.actions_accordion.set_title(self.action_index, self.action_icon)
 
         action_properties = (
@@ -2677,27 +2734,6 @@ class RegisterActionWidget(ipw.VBox):
         self.actions_accordion.set_title(self.action_index, f"{change['new']}")
 
     def remove_action(self, b):
-        current_text = self.process_step_widget.name_textbox.value
-        icon = self.action_icon
-
-        if current_text.startswith("[") and "]" in current_text:
-            close_idx = current_text.find("]")
-            prefix = current_text[: close_idx + 1]
-            rest_of_text = current_text[close_idx + 1 :]
-
-            # If the icon is inside the brackets, remove it
-            if icon in prefix:
-                # Replace only one occurrence of the icon
-                new_prefix = prefix.replace(icon, "", 1)
-
-                # If removing the icon leaves the brackets completely empty, remove them entirely
-                if new_prefix == "[]":
-                    self.process_step_widget.name_textbox.value = rest_of_text.lstrip()
-                else:
-                    self.process_step_widget.name_textbox.value = (
-                        new_prefix + rest_of_text
-                    )
-
         children = list(self.actions_accordion.children)
         children.pop(self.action_index)
 
@@ -2715,6 +2751,8 @@ class RegisterActionWidget(ipw.VBox):
             action_titles.append(action_name)
 
         set_accordion_children_titles(self.actions_accordion, children, action_titles)
+        if self.process_step_widget is not None:
+            self.process_step_widget.refresh_action_icon_prefix()
 
 
 class RegisterObservableWidget(ipw.VBox):

--- a/src/sample_preparation_widgets.py
+++ b/src/sample_preparation_widgets.py
@@ -1914,7 +1914,7 @@ class RegisterProcessStepWidget(ipw.VBox):
                 self.actions_accordion,
                 actions_accordion_children,
                 [
-                    getattr(action, "action_icon", "")
+                    action.get_action_title()
                     for action in actions_accordion_children
                 ],
             )
@@ -1976,7 +1976,7 @@ class RegisterProcessStepWidget(ipw.VBox):
                 self.actions_accordion,
                 actions_accordion_children,
                 [
-                    getattr(action, "action_icon", "")
+                    action.get_action_title()
                     for action in actions_accordion_children
                 ],
             )
@@ -2729,9 +2729,16 @@ class RegisterActionWidget(ipw.VBox):
             comp_dropdown_widget.observe(add_component_ui, names="value")
 
         self.action_properties_widgets.children = action_properties_widgets
+        self.actions_accordion.set_title(self.action_index, self.get_action_title())
 
     def change_action_title(self, change):
-        self.actions_accordion.set_title(self.action_index, f"{change['new']}")
+        self.actions_accordion.set_title(self.action_index, self.get_action_title())
+
+    def get_action_title(self):
+        for widget in self.action_properties_widgets.children:
+            if widget.metadata.get("property_name", "") == "NAME":
+                return widget.children[1].value or self.action_icon
+        return self.action_icon
 
     def remove_action(self, b):
         children = list(self.actions_accordion.children)
@@ -2740,16 +2747,7 @@ class RegisterActionWidget(ipw.VBox):
         for i in range(self.action_index, len(children)):
             children[i].action_index = i
 
-        action_titles = []
-        for action in children:
-            action_name = ""
-            if action.action_properties_widgets.children:
-                for widget in action.action_properties_widgets.children:
-                    if widget.metadata.get("property_name", "") == "NAME":
-                        action_name += widget.children[1].value
-                        break
-            action_titles.append(action_name)
-
+        action_titles = [action.get_action_title() for action in children]
         set_accordion_children_titles(self.actions_accordion, children, action_titles)
         if self.process_step_widget is not None:
             self.process_step_widget.refresh_action_icon_prefix()

--- a/src/sample_preparation_widgets.py
+++ b/src/sample_preparation_widgets.py
@@ -2911,7 +2911,11 @@ class RegisterObservableWidget(ipw.VBox):
         ]
 
     def change_observable_title(self, change):
-        self.observables_accordion.set_title(self.observable_index, f"{change['new']}")
+        self._set_observable_title(f"{change['new']}")
+
+    def _set_observable_title(self, title):
+        if self.observable_index < len(self.observables_accordion.children):
+            self.observables_accordion.set_title(self.observable_index, title)
 
     def remove_observable(self, b):
         children = list(self.observables_accordion.children)

--- a/src/widgets.py
+++ b/src/widgets.py
@@ -578,8 +578,9 @@ class MoleculeWidget(ipw.VBox):
             obj_name = obj_props.get("name", "")
             obj_empa_number = obj_props.get("empa_number", "")
             obj_empa_number_name = f"{obj_empa_number} ({obj_name})"
-            self.parent_accordion.set_title(self.object_index, obj_empa_number_name)
-            self.title = obj_name
+            if self.object_index < len(self.parent_accordion.children):
+                self.parent_accordion.set_title(self.object_index, obj_empa_number_name)
+            self.title = obj_empa_number_name
 
             obj_details_html = ipw.HTML()
             obj_details_string = (
@@ -613,16 +614,15 @@ class MoleculeWidget(ipw.VBox):
 
     def remove_molecule(self, b):
         molecules_accordion_children = list(self.parent_accordion.children)
-        num_molecules = len(molecules_accordion_children)
         molecules_accordion_children.pop(self.object_index)
 
         for index, molecule in enumerate(molecules_accordion_children):
-            if index >= self.object_index:
-                molecule.object_index -= 1
-                self.parent_accordion.set_title(molecule.object_index, molecule.title)
+            molecule.object_index = index
 
-        self.parent_accordion.set_title(num_molecules - 1, "")
         self.parent_accordion.children = molecules_accordion_children
+        self.parent_accordion.titles = tuple(
+            molecule.title for molecule in molecules_accordion_children
+        )
 
 
 class ReacProdConceptWidget(ipw.VBox):
@@ -669,7 +669,8 @@ class ReacProdConceptWidget(ipw.VBox):
             )
             obj_props = obj.props.all()
             obj_name = obj_props.get("name", "")
-            self.parent_accordion.set_title(self.object_index, obj_name)
+            if self.object_index < len(self.parent_accordion.children):
+                self.parent_accordion.set_title(self.object_index, obj_name)
             self.title = obj_name
 
             obj_details_html = ipw.HTML()
@@ -690,18 +691,16 @@ class ReacProdConceptWidget(ipw.VBox):
 
     def remove_reacprod_concept(self, b):
         reacprod_concepts_accordion_children = list(self.parent_accordion.children)
-        num_reacprod_concepts = len(reacprod_concepts_accordion_children)
         reacprod_concepts_accordion_children.pop(self.object_index)
 
         for index, reacprod_concept in enumerate(reacprod_concepts_accordion_children):
-            if index >= self.object_index:
-                reacprod_concept.object_index -= 1
-                self.parent_accordion.set_title(
-                    reacprod_concept.object_index, reacprod_concept.title
-                )
+            reacprod_concept.object_index = index
 
-        self.parent_accordion.set_title(num_reacprod_concepts - 1, "")
         self.parent_accordion.children = reacprod_concepts_accordion_children
+        self.parent_accordion.titles = tuple(
+            reacprod_concept.title
+            for reacprod_concept in reacprod_concepts_accordion_children
+        )
 
 
 class SelectInstrumentWidget(ipw.VBox):
@@ -2274,10 +2273,8 @@ class CreateSubstanceWidget(ipw.VBox):
         self.supplier_dropdown.value = "-1"
         self.receive_date.value = None
 
-        for index, _ in enumerate(self.molecules_accordion.children):
-            self.molecules_accordion.set_title(index, "")
-
         self.molecules_accordion.children = []
+        self.molecules_accordion.titles = ()
 
         self.evaporation_temperatures_table.reset_table()
 

--- a/src/widgets.py
+++ b/src/widgets.py
@@ -1077,7 +1077,12 @@ class SelectExperimentWidget(ipw.VBox):
         )
         options.sort()
         options.insert(0, ("Select experiment...", "-1"))
+        current_value = self.experiment_dropdown.value
+        option_values = {value for _, value in options}
         self.experiment_dropdown.options = options
+        self.experiment_dropdown.value = (
+            current_value if current_value in option_values else "-1"
+        )
 
     def update_project_dropdown(self, change):
         if self.raw_projects_df is None or self.raw_projects_df.empty:
@@ -1104,7 +1109,12 @@ class SelectExperimentWidget(ipw.VBox):
         )
         options.sort()
         options.insert(0, ("Select project...", "-1"))
+        current_value = self.project_dropdown.value
+        option_values = {value for _, value in options}
         self.project_dropdown.options = options
+        self.project_dropdown.value = (
+            current_value if current_value in option_values else "-1"
+        )
 
     # ==========================================
     # 4. ACTION HANDLERS


### PR DESCRIPTION
## Summary
- Add `aiidalab-eln>=0.1.4`, which includes the openBIS connector released after `0.1.3`.
- Fix setuptools package discovery by using `packages = find:` instead of `package = find:`.
- This makes `aiida_openbis` importable after an editable install in the AiiDAlab Python 3.12 environment.
- Ensure `0_home.ipynb` creates the `logs/` directory before writing `logs/upload_logs.pid`.
- Use a relative import for the sibling `custom_widgets` module in `src/sample_preparation_widgets.py`.
- Update accordion title handling to assign children before calling `set_title`, avoiding ipywidgets 8 `IndexError` while keeping ipywidgets 7-compatible API usage.

## Test notes
Tested in the real AiiDAlab instance environment, not a temporary virtualenv.

Environment:
- Python: `/opt/conda/bin/python`, 3.12.11
- aiida-core: 2.8.0
- aiidalab: 26.5.2
- ipywidgets: 8.1.8
- aiidalab-widgets-base: 3.0.0a1 from `/home/jovyan/apps/aiidalab-widgets-base`, PR aiidalab/aiidalab-widgets-base#751 checkout
- aiidalab-eln: 0.1.4 from editable checkout `/home/jovyan/opt/aiidalab-eln`; release tag `v0.1.4` was pushed to aiidalab/aiidalab-eln
- pybis: 6.9.1.0rc1

Commands/checks run:
```bash
python -m pip install -e .
python -m pip check
python -c "import pybis, aiidalab_widgets_base, aiida_openbis; print(pybis.__file__); print(aiidalab_widgets_base.__file__); print(aiida_openbis.__file__)"
python -c "from src import create_samples_widget, sample_preparation_widgets, utils; print(sample_preparation_widgets.__file__)"
python -c "import ipywidgets as ipw; from src.sample_preparation_widgets import set_accordion_children_titles; acc=ipw.Accordion(); children=[ipw.HTML('a'), ipw.HTML('b')]; set_accordion_children_titles(acc, children, ['A', 'B']); print(len(acc.children), acc.get_title(0), acc.get_title(1))"
python -c "import importlib.metadata as m, aiidalab_eln, aiida_openbis; print('aiidalab-eln', m.version('aiidalab-eln'), aiidalab_eln.__file__); print('aiidalab-openbis', m.version('aiidalab-openbis'), aiida_openbis.__file__)"
python -m compileall /home/jovyan/apps/aiidalab-openbis/src/sample_preparation_widgets.py
python -m json.tool /home/jovyan/apps/aiidalab-openbis/0_home.ipynb
```

Results:
- `pip check`: `No broken requirements found.`
- Smoke import paths:
  - `/home/jovyan/.local/lib/python3.12/site-packages/pybis/__init__.py`
  - `/home/jovyan/apps/aiidalab-widgets-base/aiidalab_widgets_base/__init__.py`
  - `/home/jovyan/apps/aiidalab-openbis/aiida_openbis/__init__.py`
- `aiidalab-eln` resolves as `0.1.4` from `/home/jovyan/opt/aiidalab-eln/aiidalab_eln/__init__.py`.
- Notebook import line succeeds for `create_samples_widget`, `sample_preparation_widgets`, and `utils`.
- Accordion helper sanity check prints `2 A B` under ipywidgets 8.1.8.
- `sample_preparation_widgets.py` compiles.
- `0_home.ipynb` remains valid JSON.

Context: this was found while testing aiidalab/aiidalab-widgets-base#751 together with aiidalab-openbis. Without the package discovery fix, the distribution installs, but `import aiida_openbis` fails with `ModuleNotFoundError`. Without `aiidalab-eln>=0.1.4`, the app can install an ELN release that does not yet contain the openBIS connector. Without the notebook fix, startup can fail with `FileNotFoundError: logs/upload_logs.pid` if `logs/` has not yet been created. Without the relative import fix, `from src import sample_preparation_widgets` fails with `ModuleNotFoundError: No module named 'custom_widgets'`. Without the accordion ordering fix, loading sample history can fail under ipywidgets 8 with `IndexError: list assignment index out of range` in `Accordion.set_title`.